### PR TITLE
Fix default handleCanvasLabel to return canvas label string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 
+### Fixed
+
+- Fixed default `handleCanvasLabel` to return a string instead of the input object
+
 ## [1.0.0](https://github.com/dbmdz/mirador-canvasnavigation/releases/tag/1.0.0) - 2026-04-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can view an example configuration in [src/demo.js][demo-cfg].
 
 The available settings are:
 
-- `handleCanvasLabel`: A function that modifies the canvas label if needed, the default implementation does not change anything.
+- `handleCanvasLabel`: A function that modifies the canvas label if needed, the default implementation returns `canvasLabel` unchanged.
   Receives this information about the current window:
   ```
   {

--- a/src/components/WindowCanvasNavigationControls.jsx
+++ b/src/components/WindowCanvasNavigationControls.jsx
@@ -130,7 +130,7 @@ const StyledPaper = styled(Paper)(({ theme }) => ({
 const WindowCanvasNavigationControls = ({
   canvasId,
   canvasLabel,
-  config: { handleCanvasLabel = (lbl) => lbl },
+  config: { handleCanvasLabel = ({ canvasLabel }) => canvasLabel },
   currentCanvasIndex,
   hasNextCanvas,
   hasPreviousCanvas,


### PR DESCRIPTION
## Purpose

`handleCanvasLabel` is called with an object: `{ canvasId, canvasLabel, currentCanvasIndex, manifestId }`, but the default implementation is `(lbl) => lbl`, which only works if the argument is a string. When no custom `handleCanvasLabel` is configured, the default returns the whole argument object, which JSX then tries to render as a child.

This crashes with React error #​31:

```
Error: Minified React error #31; ... object with keys
  {canvasId, canvasLabel, currentCanvasIndex, manifestId}
```

## Approach

Change the default in `WindowCanvasNavigationControls` to destructure the expected field: `({ canvasLabel }) => canvasLabel`.