### PR TITLE
Externalize react/jsx-runtime and react/jsx-dev-runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 
+### Fixed
+
+- Externalized `react/jsx-runtime` and `react/jsx-dev-runtime` so the published bundle no longer inlines the JSX runtime via a dynamic `require("react")`
+
 ## [1.0.0](https://github.com/dbmdz/mirador-canvasnavigation/releases/tag/1.0.0) - 2026-04-23
 
 ### Changed

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,8 @@ const pluginConfig = {
         /^@mui\/(material|system)/,
         "mirador",
         "react",
+        "react/jsx-runtime",
+        "react/jsx-dev-runtime",
         "react-dom",
         "react-i18next",
       ],


### PR DESCRIPTION
## Purpose

`vite.config.js` externalizes `react` but not the subpath specifiers `react/jsx-runtime` and `react/jsx-dev-runtime`. As a result, the published `dist/index.js` inlines the JSX runtime, including a dynamic `require("react")` call, rather than importing it from the consumer's `react` package. This leads to two issues for webpack-based consumers:

- A "Critical dependency: require function is used in a way in which dependencies cannot be statically extracted" warning for `mirador-canvasnavigation/dist/index.js`.
- In development builds, webpack can't statically resolve the dynamic `require` and replaces it with a stub that throws `Uncaught Error: Cannot find module 'react'` at runtime. Production builds aren't affected.

## Approach

Added `"react/jsx-runtime"` and `"react/jsx-dev-runtime"` to the `external` list in `vite.config.js` so the emitted bundle contains regular `import ... from "react/jsx-runtime"` statements that resolve against the host application's `react` peer dependency.